### PR TITLE
only use filename without file extension in entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ const getEndpoints = (gqlpath = defaultGqlPath, pattern = defaultPattern, option
   debugInfo('Start to load endpoints by pattern "%s", options = %o', pattern, options)
   glob.sync(pattern, options).forEach(file => {
     const query = fs.readFileSync(path.resolve(options.cwd || process.cwd(), file), 'utf8')
-    const name = `/${file}`
+    const name = `/${path.parse(file).name}`
     try {
       gql(query)
       entries[name] = query

--- a/index.test.js
+++ b/index.test.js
@@ -17,7 +17,7 @@ describe('getEndpoints()', () => {
 
   it('should receive correct graphql entry', () => {
     mock({
-      'src/endpoints/goodend': '{ example(id: 123) { title, description } }'
+      'src/endpoints/goodend.graphql': '{ example(id: 123) { title, description } }'
     })
     expect(getEndpoints()).toEqual({
       errors: 0,

--- a/index.test.js
+++ b/index.test.js
@@ -17,12 +17,36 @@ describe('getEndpoints()', () => {
 
   it('should receive correct graphql entry', () => {
     mock({
+      'src/endpoints/goodend': '{ example(id: 123) { title, description } }'
+    })
+    expect(getEndpoints()).toEqual({
+      errors: 0,
+      entries: {
+        '/goodend': '{ example(id: 123) { title, description } }'
+      }
+    })
+  })
+  
+  it('should receive correct graphql entry with .graphql', () => {
+    mock({
       'src/endpoints/goodend.graphql': '{ example(id: 123) { title, description } }'
     })
     expect(getEndpoints()).toEqual({
       errors: 0,
       entries: {
         '/goodend': '{ example(id: 123) { title, description } }'
+      }
+    })
+  })
+
+  it('should receive correct graphql entry with .test.graphql', () => {
+    mock({
+      'src/endpoints/goodend.test.graphql': '{ example(id: 123) { title, description } }'
+    })
+    expect(getEndpoints()).toEqual({
+      errors: 0,
+      entries: {
+        '/goodend.test': '{ example(id: 123) { title, description } }'
       }
     })
   })


### PR DESCRIPTION
allow schema can be named with file extension  like `.graphql` to enable syntax highlight in editor 
https://github.com/facebook/graphql/issues/203
